### PR TITLE
Using URL-encoded characters in fonts.css

### DIFF
--- a/inst/resources/css/fonts.css
+++ b/inst/resources/css/fonts.css
@@ -3,7 +3,7 @@
 @description      IOM font family definitions
 ============================================================= */
 
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700|Fira+Mono\Lato:400,300,300italic,400italic,700,700italic,900,900italic&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700%7cFira+Mono%5cLato:400,300,300italic,400italic,700,700italic,900,900italic&display=swap');
 
 html, body { font-family: 'Open Sans', Arial, sans-serif; }
 


### PR DESCRIPTION
Replaced | and \ with their encoded equivalents, as the bug fix described in [this issue](https://github.com/iom/iomdown/issues/1).